### PR TITLE
Fix metadata type

### DIFF
--- a/app/events/event.py
+++ b/app/events/event.py
@@ -11,7 +11,7 @@ class Event(ClientObject):
     visit_id: str
     event_type: str
     event_timestamp: datetime
-    event_metadata: Dict
+    event_metadata: str
     edited_at: datetime
 
     def client_insert_values(self):
@@ -20,7 +20,7 @@ class Event(ClientObject):
                 self.visit_id,
                 self.event_type,
                 self.format_ts(self.event_timestamp),
-                self.format_json(self.event_metadata),
+                self.event_metadata,
                 self.format_ts(self.edited_at)]
 
     @classmethod

--- a/app/migrations/versions/fc3a6a2ca002_make_event_metadata_text.py
+++ b/app/migrations/versions/fc3a6a2ca002_make_event_metadata_text.py
@@ -1,0 +1,28 @@
+"""make_event_metadata_text
+
+Revision ID: fc3a6a2ca002
+Revises: 628a38e43688
+Create Date: 2020-04-11 08:10:58.332881
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'fc3a6a2ca002'
+down_revision = '628a38e43688'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("DELETE FROM events;")
+    op.execute("ALTER TABLE events DROP COLUMN event_metadata;")
+    op.execute("ALTER TABLE events ADD COLUMN event_metadata TEXT;")
+
+
+def downgrade():
+    op.execute("DELETE FROM events;")
+    op.execute("ALTER TABLE events DROP COLUMN event_metadata;")
+    op.execute("ALTER TABLE events ADD COLUMN event_metadata JSONB NOT NULL DEFAULT '{}';")


### PR DESCRIPTION
Client does not always store event metadata as JSON -- it's often just raw text. This lets the server support both.